### PR TITLE
Implement commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project is an npm global tool that help developers package up their scripts
 We distribute this tool using npm. To install this in your environment, execute the following command
 
 ```sh
-npm install -g citrix-script-packager
+npm install -g citrix-scripts
 ```
 
 ## Usage
@@ -15,14 +15,16 @@ npm install -g citrix-script-packager
 To get the CLI help, execute
 
 ```sh
-citrix-script-packager --help
+citrix-scripts --help
 ```
 
-This is created to help you do two basic items
+This is created to help you do a few basic items.
 
 1. Start creating your script template
 
 2. Package up your template into a .vsix file for use with the Citrix Developer extension.
+
+3. Create a feed for use with the [Citrix Developer Extension for Visual Studio Code.](https://marketplace.visualstudio.com/items?itemName=CitrixDeveloper.citrixdeveloper-vscode)
 
 ## Getting Started
 
@@ -31,7 +33,7 @@ This is created to help you do two basic items
 The easiest way to start creating a script package is to run the following command
 
 ```sh
-citrix-script-packager --create
+citrix-scripts create
 ```
 
 This will prompt you for a few items and then create your base template layout. PLease note the friendly name that you enter, you will use this later.
@@ -41,10 +43,34 @@ This will prompt you for a few items and then create your base template layout. 
 Once you have your template all set, copied the correct script files into the friendly name location, you will need to package it up to be used within the Citrix Developer extension. You can do this with the following command
 
 ```sh
-citrix-script-packager --package
+citrix-scripts package
 ```
 
 This will create a .vsix file that can then be shared with the community and imported into the Citrix Developer extension.
+
+### Creating an RSS feed
+
+This helps you to aggregate all of your script packages that can be consumed by the Citrix Developer Extension.
+
+```sh
+citrix-scripts feed --directory [] --baseurl [url] --github
+```
+
+Let's break down the options here that you will need in order to create the RSS feed.
+
+* --directory
+    
+    The --directory option allows you to specify a location where your .vsix files are located. This can be anywhere on your computer as the script will traverse from the location you give recursivly to find all .vsix files and copy them into a vsixfeed directory.
+     
+* --baseurl
+
+    The --baseurl option if the site url where your feed.rss file will be hosted. This can be a webserver you maintain (http://www.mydomain/com/) or a file share on a network share (file:///myvisxfiles/company/) or hosted on a github url (https://www.github.com/johnmcbride/reponame)
+
+* --github
+
+    Thes github option is to be used if you are hosting the feed.rss file on a github repo. This will append '?raw=true' to the end of the link url. This is to help with downloading the binary package.
+
+
 
 ## Contributing
 

--- a/citrix-scripts-clean.js
+++ b/citrix-scripts-clean.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node --harmony
+const program = require('commander');
+const chalk = require('chalk');
+const fse = require('fs-extra');
+
+program
+    .parse(process.argv);
+
+console.log(chalk.yellow('removing the output directory and all sub directories and files...'));
+fse.removeSync('./output');
+console.log(chalk.yellow('Completed removing output directory'));
+

--- a/citrix-scripts-create.js
+++ b/citrix-scripts-create.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node --harmony
+const yoenv = require('yeoman-environment');
+const program = require('commander');
+
+program.parse(process.argv);
+
+//build a yeoman environment
+var env = yoenv.createEnv();
+//create a template
+env.register(require.resolve('./generators/index.js'),'citrix-create-scripttemplate');
+env.run('citrix-create-scripttemplate');

--- a/citrix-scripts-feed.js
+++ b/citrix-scripts-feed.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node --harmony
+
+const program = require('commander');
+const chalk = require('chalk');
+const fs = require('fs');
+const path = require('path');
+const recursive = require('recursive-readdir');
+const fse = require('fs-extra');
+const admZip = require('adm-zip');
+const toXml = require('jstoxml');
+const url = require('url').URL;
+
+program
+    .option("-d, --directory <dir>","Root directory to search for .vsix files")
+    .option("-b, --baseurl <baseurl>","Specify the base URL where the feed will be hosted. This can start with FILE:// or HTTP://")
+    .option("-g, --github","Specify this parameter if you are going to host the RSS feed on github")
+    .parse(process.argv);
+
+
+    
+if ( program.baseurl === undefined )
+{
+    console.log(chalk.red('Please specify the base url you would like to use in the RSS feed. You can use the --baseurl parameter to specify this.'));
+    return;
+}
+if ( program.directory === undefined )
+{
+    console.log(chalk.red('Please specify the directory where your .vsix script packages are located. You can use the --directory parameter to specify this.'));
+    return;
+}
+
+//defining the rss feed base
+let rssFeed = {
+    _name: 'rss',
+    _attrs: {
+        version: '2.0'
+    },
+    _content: {
+        channel: [
+            {
+                title: 'Citrix Script packages',
+                description: 'Custom feed for Citrix Script packages',
+                link: 'http://developer.citrix.com'
+            }
+        ]
+    }
+};
+
+let rssOptions = {
+    header: true,
+    indent: '  '
+};
+
+var directoryPath = path.resolve(program.directory);
+
+var destPath = path.normalize(path.resolve(`./vsixfeed/`));
+
+//clean out vsixfeed path
+console.log(chalk.yellow('removing the vsixfeed directory and all sub directories and files...'));
+fse.removeSync('./vsixfeed');
+console.log(chalk.yellow('Completed removing vsixfeed directory'));
+
+//make sure the path exists, create it if it doesnt.
+fse.mkdirpSync(destPath);
+
+//find all
+recursive(path.resolve(program.directory))
+.then( (files) => {
+    //loop through each return file and only
+    //select the vsix files.
+    files.forEach(file => {
+        var ext = path.extname(file);
+        
+        if ( ext == '.vsix')
+        {
+            var baseName = path.basename(file);
+            var fullDestPath = path.normalize(`${destPath}/${baseName}`);
+            console.log(fullDestPath);
+            
+            //make sure the path exists, create it if it doesnt.
+            fse.mkdirpSync(destPath);
+            //copy found file into the vsixfeed directory
+            fs.copyFileSync(file,fullDestPath);
+
+            let zip = new admZip(fullDestPath);
+
+            zip.getEntries().forEach(function(entry) {
+                var entryName = entry.entryName;
+
+                if ( entryName.indexOf('manifest.json') != -1 )
+                {
+                    console.log(`Found manifest file in VSIX (${baseName})`);
+                    
+                    var newVsixItem = {};
+                    newVsixItem.item = {};
+
+                    let manifest = JSON.parse(zip.readAsText(entry));
+
+                    console.log('Getting file information...');
+
+                    newVsixItem.item.title = `${manifest.packageName}`;
+
+                    newVsixItem.item.description = `${manifest.packageDescription}`;
+
+                    newVsixItem.item.author = manifest.author;
+
+                    if ( program.baseurl.endsWith('/') )
+                    {
+                        newVsixItem.item.link = `${program.baseurl}vsixfeed/${baseName}`;
+                    }
+                    else
+                    {
+                        newVsixItem.item.link = `${program.baseurl}/vsixfeed/${baseName}`;       
+                    }
+
+                    if ( program.github )
+                    {
+                        newVsixItem.item.link += '?raw=true';
+                    }
+                    console.log('Adding VSIX to the rss feed');
+                    
+                    rssFeed._content.channel.push(newVsixItem);
+                }
+                
+            });
+        }
+    }); 
+})
+.then( () => {
+    fse.writeFileSync(path.normalize(path.resolve('./vsixfeed/feed.rss')),toXml.toXML(rssFeed, rssOptions));
+    
+    console.log(chalk.green('Created rss feed'));
+    
+    var feedUrl = new url(program.baseurl);
+
+    switch (feedUrl.protocol.toLowerCase()) 
+    {
+        case 'file:':
+            console.log(chalk.green(`feed is available at ${feedUrl.protocol}//${feedUrl.host}/${path.resolve('feed.rss')}`));
+            break;
+        case 'http:':
+            console.log(chalk.green(`feed is available at ${feedUrl.protocol}//${feedUrl.host}/vsixfeed/feed.rss`));
+            break;
+        default:
+            break;
+    }
+
+});
+
+
+
+
+

--- a/citrix-scripts-package.js
+++ b/citrix-scripts-package.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node --harmony
+const program = require('commander');
+//define the manifest file
+const manifestFile = './manifest.json';
+const jsonfile = require('jsonfile');
+const chalk = require('chalk');
+const fs = require('fs');
+const archiver = require('archiver');
+const fse = require('fs-extra');
+
+program
+    .parse(process.argv);
+
+if ( !fse.existsSync(manifestFile) )
+{
+    console.log("manifest.json files doesn't exist. Maybe you need to run 'citrix-scripts create'?");
+    return;
+}
+
+var manifest = jsonfile.readFileSync(manifestFile);
+
+//clean build assests
+console.log(chalk.yellow('Cleaning existing build assets'));
+clearOutputFiles(manifest.packageName);
+
+createZip(manifest);
+
+function createZip(manifest)
+{   
+    //create the dir
+    fs.mkdirSync('./output/');
+
+    const packageFileName = `./output/${manifest.packageName}.zip`;
+
+    var output = fs.createWriteStream(packageFileName);
+
+    var archive = archiver('zip', {
+        zlib: { level: 9 } // Sets the compression level.
+    });
+
+    // good practice to catch this error explicitly
+    archive.on('error', function(err) {
+        console.log(chalk.red(err.message));
+    });
+
+    // pipe archive data to the file
+    archive.pipe(output);
+
+    console.log(chalk.yellow('Reading templates directory'));
+    
+    console.log(chalk.green(`Adding the files and directories under the 'packages' root directory to the package`));
+    //adding the zip archive using the glob feature. This also lets us
+    //configure which files do not get added to the archive.
+    archive.glob('./packages/**', { ignore: '.*'});
+
+    //add the updated manifest.json file into the zip file
+    console.log(chalk.yellow('Adding updated manifest file to the package.'));
+    archive.file('./manifest.json', {name: `/packages/${manifest.packageName}/manifest.json`})
+
+    console.log(chalk.yellow('Adding README file to the package.'));
+    archive.file('./README.md', {name: `/packages/${manifest.packageName}/README.md`})
+
+    archive.finalize();
+
+    console.log(chalk.yellow('Making VSIX file...'));
+    renameFileToVSIX(manifest.packageName);
+
+    console.log(chalk.green(`Created ./output/${manifest.packageName}.vsix`));
+    
+    console.log(chalk.green(`\nThe package is now ready to use in the Citrix VSCode extension.`)); 
+}
+
+function renameFileToVSIX(packageName)
+{
+    console.log(chalk.yellow(`Renaming ${packageName}.zip to ${packageName}.vsix`));
+    fs.renameSync(`./output/${packageName}.zip`,`./output/${packageName}.vsix`);
+    console.log(chalk.yellow('Completed renaming'));
+}
+
+function clearOutputFiles()
+{
+    console.log(chalk.yellow('removing the output directory and all sub directories and files...'));
+    fse.removeSync('./output');
+    console.log(chalk.yellow('Completed removing output directory'));
+}
+

--- a/index.js
+++ b/index.js
@@ -1,130 +1,17 @@
 #!/usr/bin/env node --harmony
-const admZip = require('adm-zip');
-const fs = require('fs');
-const archiver = require('archiver');
-const chalk = require('chalk');
-const yoenv = require('yeoman-environment');
-const jsonfile = require('jsonfile');
-const fse = require('fs-extra');
 var cmdr = require('commander');
 var package = require('./package.json');
 
-//read the manifest file
-const manifestFile = './manifest.json';
-var manifest = null;
 
 cmdr.version(package.version)
-.option('-c --create','Creates a new Citrix script package.')
-.option('-r --clean','Clean the output directory of build assets.')
-.option('-p --package','Packup up the current template files into a VSIX file for use within the Citrix Developer extension.')
-.parse(process.argv);
+    .command("create","Creates a new Citrix script package template.")
+    .command("feed","Creates the RSS feed based on the VSIX files in the specified directory.")
+    .command("package","Package up the current template files into a VSIX file.")
+    .command("clean","Cleans up the output artifacts from the package command.")
+    .parse(process.argv);
 
-//build a yeoman environment
-var env = yoenv.createEnv();
 
-if (!cmdr.create)
-{
-    if ( fse.existsSync(manifestFile) )
-    {
-        manifest = jsonfile.readFileSync(manifestFile);
-    }
-}
 
-if ( cmdr.package )
-{
-    if ( fse.existsSync(manifestFile) )
-    {
-        createPackage();
-    }
-    else
-    {
-        console.log("manifest.json files doesn't exitst. Maybe you need to run 'citrix-script-packager --create'?");
-        return;
-    }
-}
-else if ( cmdr.clean )
-{
-    if ( fse.existsSync(manifestFile) )
-    {
-        clearOutputFiles(manifest.packageName);
-    }
-    else
-    {
-        console.log("manifest.json files doesn't exitst. Maybe you need to run 'citrix-script-packager --create'?");
-        return;
-    } 
-}
-else if ( cmdr.create )
-{
-    //create a template
-    env.register(require.resolve('./generators/index.js'),'citrix-create-scripttemplate');
-    env.run('citrix-create-scripttemplate');
-}
 
-function createPackage()
-{
-    //clean build assests
-    console.log(chalk.yellow('Cleaning existing build assets'));
-    clearOutputFiles(manifest.packageName);
 
-    createZip();
-}
-function clearOutputFiles(packageName)
-{    
-    console.log(chalk.yellow('removing the output directory and all sub directories and files...'));
-    fse.removeSync('./output');
-    console.log(chalk.yellow('Completed removing output directory'));
-}
-function createZip()
-{   
-    //create the dir
-    fs.mkdirSync('./output/');
 
-    //creating the admzip object
-    const zip = new admZip();
-    const packageFileName = `./output/${manifest.packageName}.zip`;
-
-    var output = fs.createWriteStream(packageFileName);
-
-    var archive = archiver('zip', {
-        zlib: { level: 9 } // Sets the compression level.
-    });
-
-    // good practice to catch this error explicitly
-    archive.on('error', function(err) {
-        console.log(chalk.red(err.message));
-    });
-
-    // pipe archive data to the file
-    archive.pipe(output);
-
-    console.log(chalk.yellow('Reading templates directory'));
-    
-    console.log(chalk.green(`Adding the files and directories under the 'packages' root directory to the package`));
-    //adding the zip archive using the glob feature. This also lets us
-    //configure which files do not get added to the archive.
-    archive.glob('./packages/**', { ignore: '.*'});
-
-    //add the updated manifest.json file into the zip file
-    console.log(chalk.yellow('Adding updated manifest file to the package.'));
-    archive.file('./manifest.json', {name: `/packages/${manifest.packageName}/manifest.json`})
-
-    console.log(chalk.yellow('Adding README file to the package.'));
-    archive.file('./README.md', {name: `/packages/${manifest.packageName}/README.md`})
-
-    archive.finalize();
-
-    console.log(chalk.yellow('Making VSIX file...'));
-    renameFileToVSIX(manifest.packageName);
-
-    console.log(chalk.green(`Created ./output/${manifest.packageName}.vsix`));
-    
-    console.log(chalk.green(`\nThe package is now ready to use in the Citrix VSCode extension.`)); 
-}
-
-function renameFileToVSIX(packageName)
-{
-    console.log(chalk.yellow(`Renaming ${packageName}.zip to ${packageName}.vsix`));
-    fs.renameSync(`./output/${packageName}.zip`,`./output/${packageName}.vsix`);
-    console.log(chalk.yellow('Completed renaming'));
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "citrix-script-packager",
-  "version": "1.0.5",
+  "name": "citrix-scripts",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -69,15 +69,6 @@
         "readable-stream": "^2.0.0"
       }
     },
-    "argv-tools": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
-      "integrity": "sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==",
-      "requires": {
-        "array-back": "^2.0.0",
-        "find-replace": "^2.0.1"
-      }
-    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -92,14 +83,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-    },
-    "array-back": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-      "requires": {
-        "typical": "^2.6.1"
-      }
     },
     "array-differ": {
       "version": "1.0.0",
@@ -411,22 +394,10 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
-    "command-line-args": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.2.tgz",
-      "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
-      "requires": {
-        "argv-tools": "^0.1.1",
-        "array-back": "^2.0.0",
-        "find-replace": "^2.0.1",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^2.6.1"
-      }
-    },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -797,15 +768,6 @@
         }
       }
     },
-    "find-replace": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
-      "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
-      "requires": {
-        "array-back": "^2.0.0",
-        "test-value": "^3.0.0"
-      }
-    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -846,9 +808,9 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
+      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -1311,6 +1273,11 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jstoxml": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/jstoxml/-/jstoxml-1.4.3.tgz",
+      "integrity": "sha512-wKKh12TMmjdcPYd62LcKCfEEHDCZuN2SZG/2rONsxBtbM/tSeiDYWDCGqr5eIT1s1AS/yRiGK1bM4gKddKpbcQ=="
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -1355,11 +1322,6 @@
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -1838,6 +1800,14 @@
         "resolve": "^1.1.6"
       }
     },
+    "recursive-readdir": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "requires": {
+        "minimatch": "3.0.4"
+      }
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -2256,15 +2226,6 @@
         "xtend": "^4.0.0"
       }
     },
-    "test-value": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-      "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
-      "requires": {
-        "array-back": "^2.0.0",
-        "typical": "^2.6.1"
-      }
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -2345,11 +2306,6 @@
         "repeat-string": "^1.6.1"
       }
     },
-    "typical": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
-    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -2383,9 +2339,9 @@
       }
     },
     "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,21 +1,22 @@
 {
-  "name": "citrix-script-packager",
-  "version": "1.1.0",
+  "name": "citrix-scripts",
+  "version": "2.0.0",
   "description": "A script packager for the Citrix Developer Visual Studio Code extension.",
   "bin": {
-    "citrix-script-packager": "./index.js"
+    "citrix-scripts": "./index.js"
   },
   "preferGlobal": true,
   "dependencies": {
     "adm-zip": "^0.4.11",
     "archiver": "^2.1.1",
     "chalk": "^2.4.1",
-    "command-line-args": "^5.0.2",
-    "commander": "^2.15.1",
-    "fs-extra": "^6.0.1",
+    "commander": "^2.17.1",
+    "fs-extra": "^7.0.0",
     "json-query": "^2.2.2",
     "jsonfile": "^4.0.0",
+    "jstoxml": "^1.4.3",
     "make-dir": "^1.3.0",
+    "recursive-readdir": "^2.2.2",
     "walk": "^2.3.13",
     "yeoman-environment": "^2.2.0",
     "yeoman-generator": "^2.0.5"


### PR DESCRIPTION
Implemented sub commands and changed the npm name. It is now citrix-scripts as opposed to citrix-script-packager.

commands are in separate files and can be executed by the following
citrix-scripts create
citrix-scripts package
citrix-scripts clean
citrix-scripts feed

Bumped the version number so as to follow semver. Since we have breaking changes, we have moved to version 2.0.0

Updated the readme to include the changes